### PR TITLE
Limit Playwright to only chromium deps, resolves #8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/prepare
       - name: Install Playwright Browsers
-        run: pnpm playwright install --with-deps
+        run: pnpm playwright install-deps chromium
       - name: Run Playwright tests
         run: pnpm test:ci
       - uses: actions/upload-artifact@v3

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 		"lint:styles": "stylelint \"**/*.css\"",
 		"prepare": "husky install",
 		"test": "playwright test --headed",
-		"test:ci": "playwright test",
+		"test:ci": "playwright test --project=chromium",
 		"typecheck": "tsc"
 	},
 	"lint-staged": {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -17,7 +17,10 @@ export default {
 	projects: [
 		{
 			name: "chromium",
-			use: devices["Desktop Chrome"],
+			use: {
+				...devices["Desktop Chrome"],
+				channel: "chrome",
+			},
 		},
 	],
 	outputDir: "test-results/",


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to philly-js-club-site! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #8 
- [x] That issue was marked as [`status: accepting prs`](https://github.com/philly-js-club/philly-js-club-website-remix/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/philly-js-club/philly-js-club-website-remix/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

I used a combination of suggestions to reduce the time Playwright eats up in the GitHub action.