### PR TITLE
fix: add page title to ad page, resolves #17

### DIFF
--- a/app/routes/ad.tsx
+++ b/app/routes/ad.tsx
@@ -1,3 +1,4 @@
+import type { V2_MetaFunction } from "@remix-run/react";
 import { useSearchParams } from "@remix-run/react";
 
 import { AdLogo } from "~/components/AdLogo";
@@ -16,6 +17,20 @@ const monthNames = new Set([
 	"november",
 	"december",
 ]);
+
+export const meta: V2_MetaFunction<{ month: string; year: string }> = ({
+	location,
+}) => {
+	const params = new URLSearchParams(location.search);
+	const month = params.get("month")?.toLowerCase() ?? "idk";
+	const year = params.get("year")?.toLowerCase() ?? "when";
+
+	if (!monthNames.has(month) || !/\d{4}/.test(year)) {
+		return [{ title: "Ad | Philly JS Club" }];
+	}
+
+	return [{ title: `Ad (${upperFirst(month)} ${year}) | Philly JS Club` }];
+};
 
 export default function Ad() {
 	const [params] = useSearchParams();

--- a/app/routes/ad.tsx
+++ b/app/routes/ad.tsx
@@ -18,9 +18,7 @@ const monthNames = new Set([
 	"december",
 ]);
 
-export const meta: V2_MetaFunction<{ month: string; year: string }> = ({
-	location,
-}) => {
+export const meta: V2_MetaFunction = ({ location }) => {
 	const params = new URLSearchParams(location.search);
 	const month = params.get("month")?.toLowerCase() ?? "idk";
 	const year = params.get("year")?.toLowerCase() ?? "when";

--- a/app/routes/ad.tsx
+++ b/app/routes/ad.tsx
@@ -3,27 +3,11 @@ import { useSearchParams } from "@remix-run/react";
 
 import { AdLogo } from "~/components/AdLogo";
 
-const monthNames = new Set([
-	"january",
-	"february",
-	"march",
-	"april",
-	"may",
-	"june",
-	"july",
-	"august",
-	"september",
-	"october",
-	"november",
-	"december",
-]);
-
 export const meta: V2_MetaFunction = ({ location }) => {
 	const params = new URLSearchParams(location.search);
-	const month = params.get("month")?.toLowerCase() ?? "idk";
-	const year = params.get("year")?.toLowerCase() ?? "when";
+	const { month, year } = getMonthAndYear(params);
 
-	if (!monthNames.has(month) || !/\d{4}/.test(year)) {
+	if (!isValidMonth(month) || !isValidYear(year)) {
 		return [{ title: "Ad | Philly JS Club" }];
 	}
 
@@ -32,13 +16,13 @@ export const meta: V2_MetaFunction = ({ location }) => {
 
 export default function Ad() {
 	const [params] = useSearchParams();
-	const month = params.get("month")?.toLowerCase() ?? "idk";
-	if (!monthNames.has(month)) {
+	const { month, year } = getMonthAndYear(params);
+
+	if (!isValidMonth(month)) {
 		return "nope (month)";
 	}
 
-	const year = params.get("year")?.toLowerCase() ?? "when";
-	if (!/\d{4}/.test(year)) {
+	if (!isValidYear(year)) {
 		return "nope (year)";
 	}
 
@@ -59,4 +43,33 @@ export default function Ad() {
 
 function upperFirst(text: string) {
 	return text[0].toUpperCase() + text.slice(1);
+}
+
+function getMonthAndYear(params: URLSearchParams) {
+	const month = params.get("month")?.toLowerCase() ?? "idk";
+	const year = params.get("year")?.toLowerCase() ?? "when";
+	return { month, year };
+}
+
+function isValidMonth(month: string) {
+	const monthNames = new Set([
+		"january",
+		"february",
+		"march",
+		"april",
+		"may",
+		"june",
+		"july",
+		"august",
+		"september",
+		"october",
+		"november",
+		"december",
+	]);
+
+	return monthNames.has(month);
+}
+
+function isValidYear(year: string) {
+	return /\d{4}/.test(year);
 }


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to philly-js-club-site! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #17 
- [x] That issue was marked as [`status: accepting prs`](https://github.com/philly-js-club/philly-js-club-website-remix/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/philly-js-club/philly-js-club-website-remix/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

I added a valid HTML page title to the "Ad" page. 
When the "month" or "year" search params are missing or invalid, the page title will be "Ad | Philly JS Club," otherwise, it will display "Ad (${month} ${year}), same as it will display in the UI.
