### PR TITLE
feat: Add clamp to font size and line height, resolves #7

### DIFF
--- a/app/root.css
+++ b/app/root.css
@@ -7,7 +7,7 @@
 	--font-size-small: clamp(1.5rem, 4vw, 2rem);
 	--font-size-medium: clamp(1.5rem, 4vw, var(--font-size-large));
 	--font-size-large: clamp(2rem, 4vw, 3rem);
-	--font-size-larger: clamp(2.5rem, 4vw, 5rem);
+	--font-size-larger: clamp(2.5rem, 5vw, 5rem);
 	--font-size-title: clamp(7rem, 15vw, 15rem);
 	--font-weight-light: 400;
 	--font-weight-medium: 600;

--- a/app/root.css
+++ b/app/root.css
@@ -4,48 +4,24 @@
 :root {
 	--color-background: #efdb4f;
 	--color-foreground: #323330;
-	--font-size-small: 1.25rem;
-	--font-size-medium: 1.5rem;
-	--font-size-large: 2rem;
-	--font-size-larger: 2.5rem;
-	--font-size-title: 7rem;
+	--font-size-small: clamp(1.5rem, 4vw, 2rem);
+	--font-size-medium: clamp(1.5rem, 4vw, var(--font-size-large));
+	--font-size-large: clamp(2rem, 4vw, 3rem);
+	--font-size-larger: clamp(2.5rem, 4vw, 5rem);
+	--font-size-title: clamp(7rem, 15vw, 15rem);
 	--font-weight-light: 400;
 	--font-weight-medium: 600;
 	--font-weight-large: 700;
 	--font-weight-larger: 700;
 	--font-weight-title: 900;
-	--line-height-medium: 1.5rem;
-	--line-height-title: 5.5rem;
+	--line-height-medium: clamp(1.5rem, 6vw, var(--font-size-medium));
+	--line-height-title: clamp(5.5rem, 12vw, 12rem);
 	--width-main-max: 150rem;
 }
 
 @media screen and (width >= 700px) {
 	:root {
-		--font-size-small: 1.5rem;
-		--font-size-medium: var(--font-size-large);
-		--font-size-title: 10rem;
-		--line-height-medium: var(--font-size-medium);
-		--line-height-title: 8rem;
 		--padding-page: 2rem;
-	}
-}
-
-@media screen and (width >= 1000px) {
-	:root {
-		--font-size-small: 2rem;
-		--font-size-large: 2.5rem;
-		--font-size-larger: 4rem;
-		--font-size-title: 12rem;
-		--line-height-title: 9rem;
-	}
-}
-
-@media screen and (width >= 1400px) {
-	:root {
-		--font-size-large: 3rem;
-		--font-size-larger: 5rem;
-		--font-size-title: 15rem;
-		--line-height-title: 12rem;
 	}
 }
 


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to philly-js-club-site! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #7
- [x] That issue was marked as [`status: accepting prs`](https://github.com/philly-js-club/philly-js-club-website-remix/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/philly-js-club/philly-js-club-website-remix/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

Added clamp to font size and font line height. When resizing the screen size it will scale the font between the min and max sizes by desired page size. As a result, the font size changes are much smoother and easier to manage. 

## Screenshot
![image](https://github.com/philly-js-club/philly-js-club-website/assets/14133613/9d8df747-a215-4199-99bb-edcf0539c209)
![image](https://github.com/philly-js-club/philly-js-club-website/assets/14133613/7951b903-a2d4-49a4-a032-764f98cfd103)

