### PR TITLE
fix: Update font size and line height to vh, resolve #2

### DIFF
--- a/app/root.css
+++ b/app/root.css
@@ -4,7 +4,7 @@
 :root {
 	--color-background: #efdb4f;
 	--color-foreground: #323330;
-	--font-size-small: clamp(1.5rem, 4vw, 2rem);
+	--font-size-small: clamp(1vh, 4vw, var(--font-size-medium));
 	--font-size-medium: clamp(2.5vh, 5vw, var(--font-size-large));
 	--font-size-large: clamp(4vh, 5vw, 5vh);
 	--font-size-larger: clamp(4.5vh, 5vw, 8vh);

--- a/app/root.css
+++ b/app/root.css
@@ -5,10 +5,10 @@
 	--color-background: #efdb4f;
 	--color-foreground: #323330;
 	--font-size-small: clamp(1.5rem, 4vw, 2rem);
-	--font-size-medium: clamp(3vh, 5vw, var(--font-size-large));
+	--font-size-medium: clamp(2.5vh, 5vw, var(--font-size-large));
 	--font-size-large: clamp(4vh, 5vw, 5vh);
 	--font-size-larger: clamp(4.5vh, 5vw, 8vh);
-	--font-size-title: clamp(13vh, 15vw, 24vh);
+	--font-size-title: clamp(11vh, 15vw, 24vh);
 	--font-weight-light: 400;
 	--font-weight-medium: 600;
 	--font-weight-large: 700;

--- a/app/root.css
+++ b/app/root.css
@@ -5,17 +5,17 @@
 	--color-background: #efdb4f;
 	--color-foreground: #323330;
 	--font-size-small: clamp(1.5rem, 4vw, 2rem);
-	--font-size-medium: clamp(1.5rem, 4vw, var(--font-size-large));
-	--font-size-large: clamp(2rem, 4vw, 3rem);
-	--font-size-larger: clamp(2.5rem, 5vw, 5rem);
-	--font-size-title: clamp(7rem, 15vw, 15rem);
+	--font-size-medium: clamp(3vh, 5vw, var(--font-size-large));
+	--font-size-large: clamp(4vh, 5vw, 5vh);
+	--font-size-larger: clamp(4.5vh, 5vw, 8vh);
+	--font-size-title: clamp(13vh, 15vw, 24vh);
 	--font-weight-light: 400;
 	--font-weight-medium: 600;
 	--font-weight-large: 700;
 	--font-weight-larger: 700;
 	--font-weight-title: 900;
-	--line-height-medium: clamp(1.5rem, 6vw, var(--font-size-medium));
-	--line-height-title: clamp(5.5rem, 12vw, 12rem);
+	--line-height-medium: clamp(3vh, 6vw, var(--font-size-medium));
+	--line-height-title: clamp(10vh, 12vw, 20vh);
 	--width-main-max: 150rem;
 }
 

--- a/app/root.css
+++ b/app/root.css
@@ -5,17 +5,17 @@
 	--color-background: #efdb4f;
 	--color-foreground: #323330;
 	--font-size-small: clamp(2vh, 4vw, var(--font-size-medium));
-	--font-size-medium: clamp(3vh, 5vw, var(--font-size-large));
-	--font-size-large: clamp(5vh, 5vw, 5.5vh);
-	--font-size-larger: clamp(6vh, 5vw, 9vh);
-	--font-size-title: clamp(11vh, 15vw, 24vh);
+	--font-size-medium: clamp(3.4vh, 5vw, var(--font-size-large));
+	--font-size-large: clamp(3vh, 5vw, 4.4vh);
+	--font-size-larger: clamp(5.3vh, 5vw, 7.33vh);
+	--font-size-title: clamp(10.5vh, 15vw, 22vh);
 	--font-weight-light: 400;
 	--font-weight-medium: 600;
 	--font-weight-large: 700;
 	--font-weight-larger: 700;
 	--font-weight-title: 900;
 	--line-height-medium: clamp(3vh, 6vw, var(--font-size-medium));
-	--line-height-title: clamp(10vh, 12vw, 20vh);
+	--line-height-title: clamp(10vh, 12vw, 17.6vh);
 	--width-main-max: 150rem;
 }
 

--- a/app/root.css
+++ b/app/root.css
@@ -4,10 +4,10 @@
 :root {
 	--color-background: #efdb4f;
 	--color-foreground: #323330;
-	--font-size-small: clamp(1vh, 4vw, var(--font-size-medium));
-	--font-size-medium: clamp(2.5vh, 5vw, var(--font-size-large));
-	--font-size-large: clamp(4vh, 5vw, 5vh);
-	--font-size-larger: clamp(4.5vh, 5vw, 8vh);
+	--font-size-small: clamp(2vh, 4vw, var(--font-size-medium));
+	--font-size-medium: clamp(3vh, 5vw, var(--font-size-large));
+	--font-size-large: clamp(5vh, 5vw, 5.5vh);
+	--font-size-larger: clamp(6vh, 5vw, 9vh);
 	--font-size-title: clamp(11vh, 15vw, 24vh);
 	--font-weight-light: 400;
 	--font-weight-medium: 600;

--- a/app/routes/code-of-conduct.tsx
+++ b/app/routes/code-of-conduct.tsx
@@ -55,7 +55,7 @@ export default function About() {
 					<p className="body-text">
 						This Code of Conduct adapted from{" "}
 						<a
-							className="page-grid-footer-link"
+							className="page-grid-footer-link small"
 							href="https://plone.org/foundation/materials/foundation-resolutions/code-of-conduct"
 							rel="noreferrer"
 							target="_blank"

--- a/app/shared.css
+++ b/app/shared.css
@@ -30,6 +30,10 @@ Let us know if you think you've found one we'd like. 😏
 	font-weight: var(--font-weight-medium);
 }
 
+.small {
+	font-size: var(--font-size-small);
+}
+
 .body-text {
 	font-size: var(--font-size-medium);
 	font-weight: var(--font-weight-light);

--- a/app/shared.css
+++ b/app/shared.css
@@ -124,10 +124,12 @@ Let us know if you think you've found one we'd like. 😏
 }
 
 .page-grid-subtitle {
+	align-self: end;
 	font-size: var(--font-size-larger);
 	font-weight: var(--font-weight-title);
 	line-height: var(--line-height-larger);
 	text-transform: uppercase;
+	max-width: fit-content;
 }
 
 .page-grid-left {
@@ -135,7 +137,7 @@ Let us know if you think you've found one we'd like. 😏
 }
 
 .page-grid-footer {
-	align-content: flex-end;
+	align-content: end;
 	align-items: baseline;
 	display: flex;
 	flex-wrap: wrap;
@@ -144,6 +146,7 @@ Let us know if you think you've found one we'd like. 😏
 	grid-area: footer;
 	height: 100%;
 	justify-content: flex-start;
+	min-width: 350px;
 }
 
 .page-grid-footer-separator {


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to philly-js-club-site! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #002
- [x] That issue was marked as [`status: accepting prs`](https://github.com/philly-js-club/philly-js-club-website-remix/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/philly-js-club/philly-js-club-website-remix/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

Updated font size and line height to use vh rather than rem. While zooming, the text will not overlap each other and scale accordingly.

## Screenshot

### Spec: 
Resolution: 1069x490
Zoom: 200%
![image](https://github.com/philly-js-club/philly-js-club-website/assets/14133613/8c83ba8a-bdd1-44bd-b92e-72a276fe7f02)

