### PR TITLE
fix: add ascending sort for event from dates, resolve #28

### DIFF
--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -24,6 +24,7 @@ export const loader = async () => {
 		events
 			.filter(({ date }) => date > now && date < oneMonthInTheFuture)
 			.sort((a, b) => {
+				// Sort event date by ascending order.
 				if (a.date > b.date) return 1;
 				else if (a.date === b.date) return 0;
 				else return -1;

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -21,7 +21,9 @@ export const loader = async () => {
 	oneMonthInTheFuture.setUTCMonth(oneMonthInTheFuture.getUTCMonth() + 1);
 
 	return json(
-		events.filter(({ date }) => date > now && date < oneMonthInTheFuture)
+		events
+			.filter(({ date }) => date > now && date < oneMonthInTheFuture)
+			.sort((a, b) => (a.date >= b.date ? 1 : -1))
 	);
 };
 

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -21,14 +21,10 @@ export const loader = async () => {
 	oneMonthInTheFuture.setUTCMonth(oneMonthInTheFuture.getUTCMonth() + 1);
 
 	return json(
+		// Filter and sort event date in ascending order.
 		events
 			.filter(({ date }) => date > now && date < oneMonthInTheFuture)
-			.sort((a, b) => {
-				// Sort event date by ascending order.
-				if (a.date > b.date) return 1;
-				else if (a.date === b.date) return 0;
-				else return -1;
-			})
+			.sort((a, b) => a.date.getTime() - b.date.getTime())
 	);
 };
 

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -23,7 +23,11 @@ export const loader = async () => {
 	return json(
 		events
 			.filter(({ date }) => date > now && date < oneMonthInTheFuture)
-			.sort((a, b) => (a.date >= b.date ? 1 : -1))
+			.sort((a, b) => {
+				if (a.date > b.date) return 1;
+				else if (a.date === b.date) return 0;
+				else return -1;
+			})
 	);
 };
 


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to philly-js-club-site! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #028
- [x] That issue was marked as [`status: accepting prs`](https://github.com/philly-js-club/philly-js-club-website-remix/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/philly-js-club/philly-js-club-website-remix/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
Add ascending sort for event date after filtering. This order events by soonest to later.

## Screenshot
![image](https://github.com/philly-js-club/philly-js-club-website/assets/14133613/0dc53012-f11f-4e5f-843a-491708969424)

