### PR TITLE
Docs: Fixes two links in CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -22,8 +22,8 @@ There are two steps involved:
 
 ### Finding an Issue
 
-With the exception of very small typos, all changes to this repository generally need to correspond to an [open issue marked as `accepting prs` on the issue tracker](https://github.com/philly-js-club/philly-js-club-website-remix/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22).
-If this is your first time contributing, consider searching for [unassigned issues that also have the `good first issue` label](https://github.com/philly-js-club/philly-js-club-website-remix/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22+label%3A%22good+first+issue%22+no%3Aassignee).
+With the exception of very small typos, all changes to this repository generally need to correspond to an [open issue marked as `accepting prs` on the issue tracker](https://github.com/philly-js-club/philly-js-club-website/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22+).
+If this is your first time contributing, consider searching for [unassigned issues that also have the `good first issue` label](https://github.com/philly-js-club/philly-js-club-website/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22+no%3Aassignee+label%3A%22status%3A+accepting+prs%22).
 If the issue you'd like to fix isn't found on the issue, see [Reporting Issues](#reporting-issues) for filing your own (please do!).
 
 ### Sending a Pull Request

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -22,7 +22,7 @@ There are two steps involved:
 
 ### Finding an Issue
 
-With the exception of very small typos, all changes to this repository generally need to correspond to an [open issue marked as `accepting prs` on the issue tracker](https://github.com/philly-js-club/philly-js-club-website/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22+).
+With the exception of very small typos, all changes to this repository generally need to correspond to an [open issue marked as `status: accepting prs` on the issue tracker](https://github.com/philly-js-club/philly-js-club-website/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22+).
 If this is your first time contributing, consider searching for [unassigned issues that also have the `good first issue` label](https://github.com/philly-js-club/philly-js-club-website/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22+no%3Aassignee+label%3A%22status%3A+accepting+prs%22).
 If the issue you'd like to fix isn't found on the issue, see [Reporting Issues](#reporting-issues) for filing your own (please do!).
 


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to philly-js-club-site! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- 🚫 Addresses an existing open issue: fixes - I can add if needed, but this was a small change.
- 🚫 That issue was marked as [`status: accepting prs`](https://github.com/philly-js-club/philly-js-club-website-remix/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22) - There was no issue for this change.
- ✅ Steps in [CONTRIBUTING.md](https://github.com/philly-js-club/philly-js-club-website-remix/blob/main/.github/CONTRIBUTING.md) were taken

## Overview
This PR fixes two broken links in the CONTRIBUTING.md guide. The label for "accepting prs" was changed to "status:  accepting prs". It also removes the "-remix" from the repo name in the link. 
