### PR TITLE
Chore: add november 9th, 2023 event

### DIFF
--- a/app/data/events.json
+++ b/app/data/events.json
@@ -1,5 +1,16 @@
 [
 	{
+		"date": "2023-11-09T18:00:00.000-04:00",
+		"duration": {
+			"hours": 2
+		},
+		"link": "https://www.eventbrite.com/e/behind-the-code-panel-discussion-on-software-development-careers-tickets-741030440997",
+		"location": "Indy Hall",
+		"topics": [
+			"Behind the Code: Panel Discussion on Software Development Careers"
+		]
+	},
+	{
 		"date": "2023-10-27T17:00:00.000-04:00",
 		"duration": {
 			"hours": 3


### PR DESCRIPTION


## PR Checklist

- [x ] Addresses an existing open issue: fixes #001, nah.
- [x ] That issue was marked as [`status: accepting prs`](https://github.com/philly-js-club/philly-js-club-website-remix/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x ] Steps in [CONTRIBUTING.md](https://github.com/philly-js-club/philly-js-club-website-remix/blob/main/.github/CONTRIBUTING.md) were taken

## Overview
Adds November 9th career panel!
