### PR TITLE
Chore: add January 11th event

### DIFF
--- a/app/data/events.json
+++ b/app/data/events.json
@@ -1,5 +1,14 @@
 [
 	{
+		"date": "2024-1-11T19:00:00.000-04:00",
+		"duration": {
+			"hours": 2
+		},
+		"link": "https://www.eventbrite.com/e/philadelphia-javascript-club-project-showcase-tickets-784514593267",
+		"location": "Indy Hall",
+		"topics": ["Project Showcase!"]
+	},
+	{
 		"date": "2023-11-09T19:00:00.000-04:00",
 		"duration": {
 			"hours": 2


### PR DESCRIPTION
Adds January 11, 2024 event.

## PR Checklist

- [x] Addresses an existing open issue: fixes #001
- [x] That issue was marked as [`status: accepting prs`](https://github.com/philly-js-club/philly-js-club-website-remix/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/philly-js-club/philly-js-club-website-remix/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Adds January 11, 2024 event.