### PR TITLE
fix: pin isbot to 3.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 		"eslint-plugin-react-hooks": "^4.6.0",
 		"ics": "^3.1.0",
 		"ics-service": "^1.4.0",
-		"isbot": "^4.1.1",
+		"isbot": "^3.7.1",
 		"playwright": "^1.32.3",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,8 +33,8 @@ dependencies:
     specifier: ^1.4.0
     version: 1.4.0
   isbot:
-    specifier: ^4.1.1
-    version: 4.1.1
+    specifier: ^3.7.1
+    version: 3.7.1
   playwright:
     specifier: ^1.32.3
     version: 1.32.3
@@ -4764,9 +4764,9 @@ packages:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
     dev: true
 
-  /isbot@4.1.1:
-    resolution: {integrity: sha512-kN+jdL5T+4kMfENZzLwv81KFymnpuv49rUQpp6jwHQhqMG++f1XPvNBgFRO9N0uaBqqft1d+Vn1Jls/TDhJpDw==}
-    engines: {node: '>=18'}
+  /isbot@3.7.1:
+    resolution: {integrity: sha512-JfqOaY3O1lcWt2nc+D6Mq231CNpwZrBboLa59Go0J8hjGH+gY/Sy0CA/YLUSIScINmAVwTdJZIsOTk4PfBtRuw==}
+    engines: {node: '>=12'}
     dev: false
 
   /isexe@2.0.0:


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: reported by Joe in slack 😄 
- [x] That issue was marked as [`status: accepting prs`](https://github.com/philly-js-club/philly-js-club-website-remix/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/philly-js-club/philly-js-club-website-remix/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Fix broken deploys from the `isbot@4` - Internal remix `entry.server.tsx` file relies on `isbot@3`