### PR TITLE
fix: rename 'Ad' page to 'Banner'

### DIFF
--- a/app/components/AdText.tsx
+++ b/app/components/AdText.tsx
@@ -10,7 +10,7 @@ export function AdText() {
 	const { month, year } = useMonthAndYear();
 
 	return (
-		<div className="ad-text">
+		<div className="banner-text">
 			<h1>{site.title}</h1>
 			<p>
 				{upperFirst(month)} {year}

--- a/app/routes/banner.tsx
+++ b/app/routes/banner.tsx
@@ -8,7 +8,9 @@ import { getMonthAndYear } from "~/utils/dates";
 export const meta: MetaFunction = ({ location }) => {
 	const { month, year } = getMonthAndYear(new URLSearchParams(location.search));
 
-	return [{ title: constructSiteTitle(`Ad (${upperFirst(month)} ${year})`) }];
+	return [
+		{ title: constructSiteTitle(`Banner (${upperFirst(month)} ${year})`) },
+	];
 };
 
 export default function Banner() {

--- a/app/routes/banner.tsx
+++ b/app/routes/banner.tsx
@@ -11,11 +11,11 @@ export const meta: MetaFunction = ({ location }) => {
 	return [{ title: constructSiteTitle(`Ad (${upperFirst(month)} ${year})`) }];
 };
 
-export default function Ad() {
+export default function Banner() {
 	return (
-		<main className="ad-main">
-			<div className="ad-img-area">
-				<AdLogo className="ad-img" />
+		<main className="banner-main">
+			<div className="banner-img-area">
+				<AdLogo className="banner-img" />
 			</div>
 			<AdText />
 		</main>

--- a/app/shared.css
+++ b/app/shared.css
@@ -265,7 +265,7 @@ Let us know if you think you've found one we'd like. 😏
 
 /* Ad page */
 
-.ad-main {
+.banner-main {
 	align-items: center;
 	background: var(--color-foreground);
 	color: var(--color-background);
@@ -277,19 +277,19 @@ Let us know if you think you've found one we'd like. 😏
 	width: 100%;
 }
 
-.ad-img {
+.banner-img {
 	height: min(50vw, 50vh);
 	width: min(50vw, 50vh);
 }
 
-.ad-text {
+.banner-text {
 	display: flex;
 	flex-direction: column;
 	gap: 2rem;
 	text-align: center;
 }
 
-.ad-text h1 {
+.banner-text h1 {
 	font-size: 5rem;
 	font-weight: var(--font-weight-title);
 	line-height: 0.85;
@@ -297,56 +297,56 @@ Let us know if you think you've found one we'd like. 😏
 	text-transform: uppercase;
 }
 
-.ad-text p {
+.banner-text p {
 	font-size: var(--font-size-larger);
 	font-weight: 700;
 }
 
 @media screen and (width >= 700px) {
-	.ad-main {
+	.banner-main {
 		flex-direction: row;
 		gap: 2rem;
 		justify-content: center;
 		padding: 2rem;
 	}
 
-	.ad-img-area {
+	.banner-img-area {
 		text-align: right;
 		width: 50%;
 	}
 
-	.ad-img {
+	.banner-img {
 		height: 40vh;
 		width: 40vh;
 	}
 
-	.ad-text {
+	.banner-text {
 		text-align: left;
 		width: 50%;
 	}
 
-	.ad-text h1 {
+	.banner-text h1 {
 		margin: 0;
 	}
 }
 
 @media screen and (width >= 1000px) {
-	.ad-text {
+	.banner-text {
 		align-content: flex-start;
 	}
 
-	.ad-text h1 {
+	.banner-text h1 {
 		font-size: 7rem;
 	}
 }
 
 @media screen and (width >= 1400px) {
-	.ad-img {
+	.banner-img {
 		height: 50vh;
 		width: 50vh;
 	}
 
-	.ad-text h1 {
+	.banner-text h1 {
 		font-size: 10rem;
 	}
 }

--- a/app/shared.css
+++ b/app/shared.css
@@ -263,7 +263,7 @@ Let us know if you think you've found one we'd like. 😏
 	}
 }
 
-/* Ad page */
+/* Banner page */
 
 .banner-main {
 	align-items: center;


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #88
- [x] That issue was marked as [`status: accepting prs`](https://github.com/philly-js-club/philly-js-club-website-remix/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/philly-js-club/philly-js-club-website-remix/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Straightforward move and rename. I don't think blockers normally block _"banner"_?

Example page to try: `/banner?month=january&year=2024`