### PR TITLE
Isolate build/deploy actions to main repo

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,6 @@
 jobs:
   build:
+    if: github.repository == 'philly-js-club/philly-js-club-website'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   build:
+    if: github.repository == 'philly-js-club/philly-js-club-website'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
I noticed a bunch of failures from these actions running on the cron job in my repo where the ENV values aren't set - this is how we prevent that in Remix actions

