### PR TITLE
chore: remove unnecessary unstable_defineLoader

### DIFF
--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -1,4 +1,3 @@
-import { unstable_defineLoader } from "@remix-run/node";
 import type { MetaFunction } from "@remix-run/react";
 import { useLoaderData } from "@remix-run/react";
 
@@ -8,7 +7,7 @@ import { constructSiteTitle } from "~/utils/common";
 
 import eventsJson from "../data/events.json";
 
-export const loader = unstable_defineLoader(() => {
+export function loader() {
 	// This assumes the events are always in sorted order, newest first.
 	// Surely this assumption on undocumented data behavior will never come back to haunt us.
 	const events = eventsJson.map((event) => ({
@@ -27,7 +26,7 @@ export const loader = unstable_defineLoader(() => {
 	return events
 		.filter(({ date }) => date > now && date < sixWeeksInTheFuture)
 		.sort((a, b) => a.date.getTime() - b.date.getTime());
-});
+}
 
 export const meta: MetaFunction = () => {
 	return [{ title: constructSiteTitle() }];
@@ -46,7 +45,7 @@ export default function Index() {
 						</h2>
 						{events.map((event, index) => (
 							<EventDetails
-								date={new Date(event.date)}
+								date={event.date}
 								key={index}
 								link={event.link}
 								linkText="Register Now"

--- a/app/routes/about.tsx
+++ b/app/routes/about.tsx
@@ -1,4 +1,3 @@
-import { unstable_defineLoader } from "@remix-run/node";
 import { type MetaFunction, useLoaderData } from "@remix-run/react";
 
 import { PageGrid } from "~/components/PageGrid";
@@ -10,7 +9,9 @@ export const meta: MetaFunction = () => {
 	return [{ title: constructSiteTitle("About") }];
 };
 
-export const loader = unstable_defineLoader(() => team);
+export function loader() {
+	return team;
+}
 
 export default function About() {
 	const data = useLoaderData<typeof loader>();

--- a/app/routes/events.tsx
+++ b/app/routes/events.tsx
@@ -1,4 +1,3 @@
-import { unstable_defineLoader } from "@remix-run/node";
 import type { MetaFunction } from "@remix-run/react";
 import { useLoaderData } from "@remix-run/react";
 
@@ -10,9 +9,9 @@ import { constructSiteTitle, groupBy } from "~/utils/common";
 
 import events from "../data/events.json";
 
-export const loader = unstable_defineLoader(() => {
+export function loader() {
 	return groupBy(events, (event) => new Date(event.date).getFullYear());
-});
+}
 
 export const meta: MetaFunction = () => {
 	return [{ title: constructSiteTitle("Events") }];
@@ -20,6 +19,7 @@ export const meta: MetaFunction = () => {
 
 export default function Events() {
 	const data = useLoaderData<typeof loader>();
+	console.log(data);
 
 	return (
 		<PageGrid

--- a/app/routes/ics-feed[.ics].ts
+++ b/app/routes/ics-feed[.ics].ts
@@ -1,4 +1,3 @@
-import { unstable_defineLoader } from "@remix-run/node";
 import type { DurationObject, EventAttributes } from "ics";
 import icsService from "ics-service";
 
@@ -6,7 +5,7 @@ import { site } from "~/config";
 
 import eventJson from "../data/events.json";
 
-export const loader = unstable_defineLoader(() => {
+export function loader() {
 	const eventData = [...eventJson].reverse();
 	const events: EventAttributes[] = eventData.map((event, index) => {
 		const date = new Date(event.date);
@@ -42,4 +41,4 @@ export const loader = unstable_defineLoader(() => {
 			"Content-Disposition": `attachment; filename="phillyjs.ics"`,
 		},
 	});
-});
+}

--- a/app/routes/join-us.tsx
+++ b/app/routes/join-us.tsx
@@ -1,4 +1,3 @@
-import { unstable_defineLoader } from "@remix-run/node";
 import { type MetaFunction, useLoaderData } from "@remix-run/react";
 
 import { Icons } from "~/components/Icons";
@@ -7,7 +6,9 @@ import { constructSiteTitle } from "~/utils/common";
 
 import platforms from "../data/platforms.json";
 
-export const loader = unstable_defineLoader(() => platforms);
+export function loader() {
+	return platforms;
+}
 
 export const meta: MetaFunction = () => {
 	return [{ title: constructSiteTitle("Join Us") }];

--- a/app/routes/sponsors.tsx
+++ b/app/routes/sponsors.tsx
@@ -1,4 +1,3 @@
-import { unstable_defineLoader } from "@remix-run/node";
 import { type MetaFunction, useLoaderData } from "@remix-run/react";
 
 import { Icons } from "~/components/Icons";
@@ -7,7 +6,9 @@ import { constructSiteTitle } from "~/utils/common";
 
 import sponsors from "../data/sponsors.json";
 
-export const loader = unstable_defineLoader(() => sponsors);
+export function loader() {
+	return sponsors;
+}
 
 export const meta: MetaFunction = () => {
 	return [{ title: constructSiteTitle("Sponsors") }];


### PR DESCRIPTION
In preparation for the livestream tomorrow - removing the `unstable_defineLoader` API that shipped originally with Single Fetch but is going to be removed in an upcoming Remix release.  That way we don't show anyone any dead APIs that's are on the way out.  We still get effectively the same + correct type-inference from `export function loader` in our simplistic use cases