### PR TITLE
fix: use native <details> for calendar subscription links

### DIFF
--- a/app/components/CalendarSubscriptionLinks.tsx
+++ b/app/components/CalendarSubscriptionLinks.tsx
@@ -1,5 +1,3 @@
-import { useState } from "react";
-
 interface CalendarSubscriptionLinksProps {
 	webcalUrl: string;
 }
@@ -7,33 +5,21 @@ interface CalendarSubscriptionLinksProps {
 export function CalendarSubscriptionLinks({
 	webcalUrl,
 }: CalendarSubscriptionLinksProps) {
-	const [showMore, setShowMore] = useState(false);
-
 	return (
-		<div className="calendar-subscription">
-			<button
-				onClick={() => {
-					setShowMore((s) => !s);
-				}}
-			>
-				📆 Subscribe with your favorite calendar client
-			</button>
-			{showMore && (
-				<>
-					<p>
-						<a href={`https://www.google.com/calendar/render?cid=${webcalUrl}`}>
-							Subscribe with Google Calendar
-						</a>
-					</p>
-					<p>To subscribe, point your calendar client to the following URL:</p>
-					<p>{webcalUrl}</p>
-					<p>
-						⚠️ Be sure to not download and import that file! You'll need to
-						subscribe to the calendar updates in order for your calendar client
-						to continue to fetch new events.
-					</p>
-				</>
-			)}
-		</div>
+		<details className="calendar-subscription">
+			<summary>📆 Subscribe with your favorite calendar client</summary>
+			<p>
+				<a href={`https://www.google.com/calendar/render?cid=${webcalUrl}`}>
+					Subscribe with Google Calendar
+				</a>
+			</p>
+			<p>To subscribe, point your calendar client to the following URL:</p>
+			<p>{webcalUrl}</p>
+			<p>
+				⚠️ Be sure to not download and import that file! You'll need to
+				subscribe to the calendar updates in order for your calendar client to
+				continue to fetch new events.
+			</p>
+		</details>
 	);
 }

--- a/app/shared.css
+++ b/app/shared.css
@@ -132,7 +132,6 @@ Let us know if you think you've found one we'd like. 😏
 }
 
 .page-grid-footer {
-	align-content: flex-end;
 	align-items: baseline;
 	display: flex;
 	flex-wrap: wrap;
@@ -140,7 +139,7 @@ Let us know if you think you've found one we'd like. 😏
 	font-weight: var(--font-weight-large);
 	grid-area: footer;
 	height: 100%;
-	justify-content: flex-start;
+	place-content: flex-end flex-start;
 }
 
 .page-grid-footer-separator {
@@ -236,14 +235,15 @@ Let us know if you think you've found one we'd like. 😏
 	font-size: var(--font-size-small);
 }
 
-.calendar-subscription button {
+.calendar-subscription summary {
 	background: var(--color-background);
 	border: 2px solid var(--color-foreground);
 	border-radius: 1em;
 	color: var(--color-foreground);
 	cursor: pointer;
+	display: inline-block;
 	font-size: var(--font-size-smaller);
-	margin: 1em 0;
+	margin: 0 0 1.5rem;
 	padding: 0.5em;
 	text-align: left;
 	width: auto;


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #107
- [x] That issue was marked as [`status: accepting prs`](https://github.com/philly-js-club/philly-js-club-website-remix/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/philly-js-club/philly-js-club-website-remix/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Swaps over from React state to a native `<details>`.

Also coincidentally switches the button/summary to use the same font as the rest of the page. Cool.

cc @RNR1 

💖 