### PR TITLE
bug: update cspell to ignore playwright-report directory

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -6,6 +6,7 @@
 		"build",
 		"node_modules",
 		"pnpm-lock.yaml",
+		"playwright-report",
 		"public",
 		"_out"
 	],


### PR DESCRIPTION


## PR Checklist

- [X] Addresses an existing open issue: fixes #110
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/philly-js-club/philly-js-club-website-remix/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22) - I created the issue so doesn't have label yet
- [X] Steps in [CONTRIBUTING.md](https://github.com/philly-js-club/philly-js-club-website-remix/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

cspell now ignores `playwright-report` directory.  The report directory produced by running `test`