### PR TITLE
Fix: #120 update actions to use node 20

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ jobs:
     if: github.repository == 'philly-js-club/philly-js-club-website'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/prepare
       - run: pnpm build
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -16,15 +16,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: "20.2"
 
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
@@ -47,7 +47,7 @@ jobs:
           echo "phillyjs.com" > out/CNAME
 
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
           publish_dir: ./out

--- a/package.json
+++ b/package.json
@@ -81,6 +81,6 @@
 		"yaml-eslint-parser": "^1.2.3"
 	},
 	"engines": {
-		"node": ">=14"
+		"node": ">=20"
 	}
 }


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to philly-js-club-site! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #120
- [x] That issue was marked as [`status: accepting prs`](https://github.com/philly-js-club/philly-js-club-website/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/philly-js-club/philly-js-club-website/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
There are deprecation warnings in each scheduled action that point to notices [like this](https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/). I checked each action repo and bumping them all to `v4` seemed to be all that's needed to fix the warnings. I figured I'd bump up the node engine version in package.json since that was mentioned in the bug report.

I've never worked out a good way to test github actions but I'm fairly confident this'll work!