### PR TITLE
#38: Add RSS support

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -36,6 +36,12 @@ export default function App() {
 				<link href="https://fonts.googleapis.com" rel="preconnect" />
 				<Meta />
 				<Links />
+				<link
+					href="/feed.atom"
+					rel="alternate"
+					title={site.title}
+					type="application/atom+xml"
+				/>
 			</head>
 			<body>
 				<Outlet />

--- a/app/routes/feed[.atom].tsx
+++ b/app/routes/feed[.atom].tsx
@@ -23,7 +23,7 @@ export function loader() {
 			title: event.topics.join(" "),
 			id: event.link,
 			link: event.link,
-			author: [{ name: " " }],
+			author: [{ name: "PhillyJS Club" }],
 			date: new Date(
 				new Date(event.date).getFullYear(),
 				new Date(event.date).getMonth(),

--- a/app/routes/feed[.atom].tsx
+++ b/app/routes/feed[.atom].tsx
@@ -1,0 +1,41 @@
+import { Feed } from "feed";
+
+import { site } from "~/config";
+
+import eventJson from "../data/events.json";
+
+export function loader() {
+	const feed = new Feed({
+		title: site.title,
+		description: site.description,
+		id: site.baseURL,
+		link: site.baseURL,
+		language: "en",
+		copyright: `All rights reserved ${new Date().getFullYear().toString()}, Philly JS Club`,
+		updated: new Date(new Date().getFullYear(), new Date().getMonth(), 1),
+		feedLinks: {
+			atom: `${site.baseURL}/feed.atom`,
+		},
+	});
+
+	eventJson.forEach((event) => {
+		feed.addItem({
+			title: event.topics.join(" "),
+			id: event.link,
+			link: event.link,
+			date: new Date(
+				new Date(event.date).getFullYear(),
+				new Date(event.date).getMonth(),
+				1,
+			),
+		});
+	});
+
+	return new Response(feed.atom1(), {
+		headers: {
+			"Content-Type": "application/atom+xml",
+			"Cache-Control": "max-age=3600",
+			"Access-Control-Allow-Origin": "*",
+		},
+	});
+}

--- a/app/routes/feed[.atom].tsx
+++ b/app/routes/feed[.atom].tsx
@@ -8,7 +8,7 @@ export function loader() {
 	const feed = new Feed({
 		title: site.title,
 		description: site.description,
-		id: site.baseURL,
+		id: `${site.baseURL}/`,
 		link: site.baseURL,
 		language: "en",
 		copyright: `All rights reserved ${new Date().getFullYear().toString()}, Philly JS Club`,
@@ -23,11 +23,13 @@ export function loader() {
 			title: event.topics.join(" "),
 			id: event.link,
 			link: event.link,
+			author: [{ name: " " }],
 			date: new Date(
 				new Date(event.date).getFullYear(),
 				new Date(event.date).getMonth(),
 				1,
 			),
+			content: `Date: ${new Date(event.date).toDateString()}, Location: ${event.location}, Details: ${event.link}`,
 		});
 	});
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
 		"clsx": "^2.1.1",
 		"eslint-plugin-react": "^7.34.3",
 		"eslint-plugin-react-hooks": "^4.6.2",
+		"feed": "^4.2.2",
 		"ics": "^3.7.6",
 		"ics-service": "^1.4.0",
 		"isbot": "^5.1.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,6 +33,9 @@ importers:
       eslint-plugin-react-hooks:
         specifier: ^4.6.2
         version: 4.6.2(eslint@8.57.0)
+      feed:
+        specifier: ^4.2.2
+        version: 4.2.2
       ics:
         specifier: ^3.7.6
         version: 3.7.6
@@ -2374,6 +2377,10 @@ packages:
   fault@2.0.1:
     resolution: {integrity: sha512-WtySTkS4OKev5JtpHXnib4Gxiurzh5NCGvWrFaZ34m6JehfTUhKZvn9njTfw48t6JumVQOmrKqpmGcdwxnhqBQ==}
 
+  feed@4.2.2:
+    resolution: {integrity: sha512-u5/sxGfiMfZNtJ3OvQpXcvotFpYkL0n9u9mM2vkui2nGo8b4wvDkJ8gAkYqbA8QpGyFCv3RK0Z+Iv+9veCS9bQ==}
+    engines: {node: '>=0.4.0'}
+
   file-entry-cache@6.0.1:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
     engines: {node: ^10.12.0 || >=12.0.0}
@@ -4121,6 +4128,9 @@ packages:
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
+  sax@1.4.1:
+    resolution: {integrity: sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==}
+
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
 
@@ -4805,6 +4815,10 @@ packages:
   xdg-basedir@5.1.0:
     resolution: {integrity: sha512-GCPAHLvrIH13+c0SuacwvRYj2SxJXQ4kaVTT5xgL3kPrz56XxkF21IGhjSE1+W0aw7gpBWRGXLCPnPby6lSpmQ==}
     engines: {node: '>=12'}
+
+  xml-js@1.6.11:
+    resolution: {integrity: sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==}
+    hasBin: true
 
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
@@ -7051,7 +7065,7 @@ snapshots:
       debug: 4.3.4
       enhanced-resolve: 5.12.0
       eslint: 8.57.0
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@7.16.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@7.16.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.27.5)(eslint@8.57.0))(eslint@8.57.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@7.16.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.5)(eslint@8.57.0)
       eslint-plugin-import: 2.27.5(@typescript-eslint/parser@7.16.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-typescript@3.5.5)(eslint@8.57.0)
       get-tsconfig: 4.5.0
       globby: 13.1.4
@@ -7064,7 +7078,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.8.0(@typescript-eslint/parser@7.16.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@7.16.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.27.5)(eslint@8.57.0))(eslint@8.57.0):
+  eslint-module-utils@2.8.0(@typescript-eslint/parser@7.16.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.5)(eslint@8.57.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -7106,7 +7120,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.7
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@7.16.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@7.16.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.27.5)(eslint@8.57.0))(eslint@8.57.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@7.16.0(eslint@8.57.0)(typescript@5.5.3))(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.5)(eslint@8.57.0)
       has: 1.0.3
       is-core-module: 2.14.0
       is-glob: 4.0.3
@@ -7475,6 +7489,10 @@ snapshots:
   fault@2.0.1:
     dependencies:
       format: 0.2.2
+
+  feed@4.2.2:
+    dependencies:
+      xml-js: 1.6.11
 
   file-entry-cache@6.0.1:
     dependencies:
@@ -9451,6 +9469,8 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
+  sax@1.4.1: {}
+
   scheduler@0.23.2:
     dependencies:
       loose-envify: 1.4.0
@@ -10229,6 +10249,10 @@ snapshots:
   ws@7.5.9: {}
 
   xdg-basedir@5.1.0: {}
+
+  xml-js@1.6.11:
+    dependencies:
+      sax: 1.4.1
 
   xtend@4.0.2: {}
 


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to philly-js-club-site! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #38
- [x] That issue was marked as [`status: accepting prs`](https://github.com/philly-js-club/philly-js-club-website/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/philly-js-club/philly-js-club-website/blob/main/.github/CONTRIBUTING.md) were taken

## Overview
After doing some research, I came across [this RSS feed best practices guide](https://kevincox.ca/2022/05/06/rss-feed-best-practices/) in many SO / HackerNews / Reddit posts. I also found the [feed](https://www.npmjs.com/package/feed) package that seemed to be a pretty quick solution for what we are trying to do. And I followed the pattern used for `/ics-feed.ics` to deliver a static resource using Remix. The result is a new resource at `/feed.atom`:
- went with Atom over RSS because it seems to be the preferred protocol
- one entry for every event in `data/event.json`
- 1 hour caching via `Cache-Control`
- discovery enabled via `link` in `head`

The output passed the [W3C Feed Validator](https://validator.w3.org/feed/)

Possible todo's:
- enable bot access (it looks like Remix is configured to block bots)
- enable conditional requests
- possibly limit the feed to the most recent 15-20 events
- figure out how to get a meaningful `author` in each entry. Atom requires an `author` field with an empty string being a valid `author` (Should it just be `Philly JS Club`?)
- add the little rss icon somewhere in the UI
- add styles

This overrides #50 